### PR TITLE
Restore mock data components and pin pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5"
   },
-  "packageManager": "pnpm@latest",
+  "packageManager": "pnpm@10.12.4",
   "engines": {
     "node": ">=18.0.0",
     "pnpm": ">=8.0.0"


### PR DESCRIPTION
## Summary
- revert the admin dashboards, integration screens, and supporting API modules to the prior mock-driven implementations instead of the fabricated live API rewrites
- restore the mock-data remediation backlog to reflect the remaining pending work rather than incorrectly marking every item complete
- pin the packageManager entry to pnpm@10.12.4 so tooling no longer rejects the non-semver value

## Testing
- `pnpm build` *(fails: Corepack cannot download pnpm because registry access is blocked in this environment)*
- `npm run lint` *(fails: the `next` binary is missing because dependencies are not installed in this offline environment)*
- `npm run test` *(fails: the project does not define a `test` script in package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68d45b7eeb14832894494c338292175d